### PR TITLE
fix(ci): enhance CI workflow with AWS secret detection for Docker deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         fail_ci_if_error: false
 
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results
@@ -98,7 +98,7 @@ jobs:
         poetry run safety check --json --output safety-report.json || true
 
     - name: Upload security reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: security-reports
@@ -133,7 +133,7 @@ jobs:
       run: poetry build
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
         path: dist/


### PR DESCRIPTION
- Added a step to set an environment variable indicating the presence of AWS credentials.
- Updated conditions for building and pushing Docker images to ECR based on the new environment variable.
- Improved handling of scenarios where AWS secrets are not set, ensuring clearer workflow management.